### PR TITLE
Set verbatimModuleSyntax to true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "noUnusedParameters": true,
     "strict": true,
     "target": "es2020",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: this will throw errors during Typescript compilation when types are not imported using the `import type` keywords. 

See prior discussion on [octokit/auth-token.js#345](https://github.com/octokit/auth-token.js/pull/345). 