### PR TITLE
chore: remove dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![@latest](https://img.shields.io/npm/v/@octokit/tsconfig.svg)](https://www.npmjs.com/package/@octokit/tsconfig)
 [![Build Status](https://github.com/octokit/tsconfig/workflows/Test/badge.svg)](https://github.com/octokit/tsconfig/actions?query=workflow%3ATest+branch%3Amain)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=octokit/tsconfig)](https://dependabot.com/)
 
 ## Usage
 


### PR DESCRIPTION
THe badge is broken and should be removed.

https://github.com/dependabot/dependabot-core/issues/1912