### PR TITLE
Target es2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "branches": [
       "main"
     ]
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
     "branches": [
       "main"
     ]
-  },
-  "engines": {
-    "node": ">=18"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,15 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Octokit TSConfig",
+
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "target": "es2020",
+    "target": "es2022",
+    "lib": ["es2022"],
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true
   }


### PR DESCRIPTION
We afaik support node 18+

https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-18

The @tsconfig/node18 package is even targetting es2023. But I think this is because node 18.0.0 was supporting es2022 and later updated v8 and supports later es2023.

Also @tsconfig/node uses differnt module and moduleResolution (in both cases node16) which should be actually the better option, but I did not touch that. 

Imho semver-major.