### PR TITLE
feat: enable `exactOptioanlPropertyTypes` option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "target": "es2022",
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Required, but potentially undefined does not have the same intent as optional. This
rule will enforce us to be explicit in our type declarations and how we expect octokit APIs should
be used.

fix #29
